### PR TITLE
fix: notifications not displaying for menu bar app

### DIFF
--- a/MacThrottle/Services/ThermalMonitor.swift
+++ b/MacThrottle/Services/ThermalMonitor.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import UserNotifications
 
 @Observable
-final class ThermalMonitor {
+final class ThermalMonitor: NSObject, UNUserNotificationCenterDelegate {
     // MARK: - Constants
     private static let historyDurationSeconds: TimeInterval = 600  // 10 minutes
     private static let pollIntervalSeconds: TimeInterval = 2.0
@@ -74,9 +74,21 @@ final class ThermalMonitor {
         return Date().timeIntervalSince(first.timestamp)
     }
 
-    init() {
+    override init() {
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
         requestNotificationPermission()
         startMonitoring()
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
     }
 
     deinit {


### PR DESCRIPTION
I noticed notifications weren't triggering on my Mac despite having them enabled in the menu. After investigating, I found the root cause: macOS silences notifications for foreground apps by default, and menu bar apps like MacThrottle (configured with `LSUIElement`, meaning no Dock icon) are treated as foreground.

The fix implements `UNUserNotificationCenterDelegate` and adds the `willPresent` delegate method to explicitly request banner presentation. This affects all users on all macOS versions since 10.14 Mojave.

Changes:
- Add `UNUserNotificationCenterDelegate` conformance to `ThermalMonitor`
- Set notification center delegate on init
- Implement `willPresent` to call completion handler with `.banner` and `.sound`

I've found this utility invaluable and have been using it constantly since reading your blog post a few weeks ago. I'm slightly new to OSS development, so let me know if I should change or improve anything. Thanks!