### PR TITLE
Add manual update check

### DIFF
--- a/MacThrottle.xcodeproj/project.pbxproj
+++ b/MacThrottle.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A1000024229E8F1100000001 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000023229E8F1100000001 /* AboutView.swift */; };
 		A1000029229E8F1100000001 /* ThermalPressureReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000028229E8F1100000001 /* ThermalPressureReader.swift */; };
 		A100002C229E8F1100000001 /* LaunchAtLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100002B229E8F1100000001 /* LaunchAtLoginManager.swift */; };
+		A100002E229E8F1100000001 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100002D229E8F1100000001 /* UpdateChecker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,7 @@
 		A1000028229E8F1100000001 /* ThermalPressureReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalPressureReader.swift; sourceTree = "<group>"; };
 		A100002A229E8F1100000001 /* MacThrottle.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MacThrottle.entitlements; sourceTree = "<group>"; };
 		A100002B229E8F1100000001 /* LaunchAtLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginManager.swift; sourceTree = "<group>"; };
+		A100002D229E8F1100000001 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +106,7 @@
 				A1000028229E8F1100000001 /* ThermalPressureReader.swift */,
 				A1000018229E8F1100000001 /* TemperatureReaders.swift */,
 				A100002B229E8F1100000001 /* LaunchAtLoginManager.swift */,
+				A100002D229E8F1100000001 /* UpdateChecker.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -187,6 +190,7 @@
 				A1000029229E8F1100000001 /* ThermalPressureReader.swift in Sources */,
 				A1000017229E8F1100000001 /* TemperatureReaders.swift in Sources */,
 				A100002C229E8F1100000001 /* LaunchAtLoginManager.swift in Sources */,
+				A100002E229E8F1100000001 /* UpdateChecker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacThrottle/Services/UpdateChecker.swift
+++ b/MacThrottle/Services/UpdateChecker.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+private struct GitHubRelease: Decodable {
+    let tagName: String
+    let htmlURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case htmlURL = "html_url"
+    }
+}
+
+private enum UpdateError: LocalizedError {
+    case invalidReleaseURL
+    case invalidResponse
+    case requestFailed(Int)
+    case missingVersion
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidReleaseURL:
+            return "The update check URL is invalid."
+        case .invalidResponse:
+            return "GitHub returned an invalid response."
+        case .requestFailed(let statusCode):
+            return "GitHub returned HTTP \(statusCode)."
+        case .missingVersion:
+            return "The latest release did not include a version."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class UpdateChecker {
+    struct AvailableUpdate: Equatable {
+        let version: String
+        let releaseURL: URL
+    }
+
+    enum Status: Equatable {
+        case idle
+        case checking
+        case updateAvailable(AvailableUpdate)
+        case upToDate(latestVersion: String)
+        case failed(String)
+    }
+
+    private static let latestReleaseURLString = "https://api.github.com/repos/angristan/MacThrottle/releases/latest"
+
+    private(set) var status: Status = .idle
+
+    var isChecking: Bool {
+        status == .checking
+    }
+
+    func checkForUpdates() async {
+        guard !isChecking else { return }
+
+        status = .checking
+
+        do {
+            let release = try await fetchLatestRelease()
+            let latestVersion = Self.normalizedVersion(release.tagName)
+
+            guard !latestVersion.isEmpty else {
+                throw UpdateError.missingVersion
+            }
+
+            if Self.isVersion(latestVersion, newerThan: Self.currentVersion) {
+                status = .updateAvailable(
+                    AvailableUpdate(version: latestVersion, releaseURL: release.htmlURL)
+                )
+            } else {
+                status = .upToDate(latestVersion: latestVersion)
+            }
+        } catch {
+            status = .failed(error.localizedDescription)
+        }
+    }
+
+    private func fetchLatestRelease() async throws -> GitHubRelease {
+        guard let latestReleaseURL = URL(string: Self.latestReleaseURLString) else {
+            throw UpdateError.invalidReleaseURL
+        }
+
+        var request = URLRequest(url: latestReleaseURL, timeoutInterval: 15)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("MacThrottle", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw UpdateError.invalidResponse
+        }
+
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw UpdateError.requestFailed(httpResponse.statusCode)
+        }
+
+        return try JSONDecoder().decode(GitHubRelease.self, from: data)
+    }
+
+    private static var currentVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        return normalizedVersion(version ?? "0")
+    }
+
+    private static func isVersion(_ candidate: String, newerThan current: String) -> Bool {
+        let candidateComponents = versionComponents(from: candidate)
+        let currentComponents = versionComponents(from: current)
+        let componentCount = max(candidateComponents.count, currentComponents.count)
+
+        for index in 0..<componentCount {
+            let candidateValue = value(at: index, in: candidateComponents)
+            let currentValue = value(at: index, in: currentComponents)
+
+            if candidateValue != currentValue {
+                return candidateValue > currentValue
+            }
+        }
+
+        return false
+    }
+
+    private static func versionComponents(from version: String) -> [Int] {
+        let coreVersion = normalizedVersion(version)
+            .split(separator: "-", maxSplits: 1)
+            .first ?? ""
+
+        return coreVersion
+            .split(separator: ".")
+            .map { Int($0) ?? 0 }
+    }
+
+    private static func normalizedVersion(_ version: String) -> String {
+        let trimmedVersion = version
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedVersion.lowercased().hasPrefix("v") {
+            return String(trimmedVersion.dropFirst())
+        }
+
+        return trimmedVersion
+    }
+
+    private static func value(at index: Int, in components: [Int]) -> Int {
+        index < components.count ? components[index] : 0
+    }
+}

--- a/MacThrottle/Views/AboutView.swift
+++ b/MacThrottle/Views/AboutView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct AboutView: View {
+    @State private var updateChecker = UpdateChecker()
+
     var body: some View {
         VStack(spacing: 16) {
             if #available(macOS 26.0, *) {
@@ -29,6 +31,8 @@ struct AboutView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
+            updateSection
+
             if let url = URL(string: "https://github.com/angristan/MacThrottle") {
                 if #available(macOS 26.0, *) {
                     Link("View on GitHub", destination: url)
@@ -41,6 +45,64 @@ struct AboutView: View {
             }
         }
         .padding(32)
-        .frame(width: 300)
+        .frame(width: 320)
+    }
+
+    @ViewBuilder
+    private var updateSection: some View {
+        VStack(spacing: 8) {
+            Button {
+                Task {
+                    await updateChecker.checkForUpdates()
+                }
+            } label: {
+                if updateChecker.isChecking {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Checking...")
+                    }
+                } else {
+                    Label("Check for Updates", systemImage: "arrow.clockwise")
+                }
+            }
+            .disabled(updateChecker.isChecking)
+            .controlSize(.small)
+            .frame(minWidth: 150)
+
+            updateStatus
+        }
+    }
+
+    @ViewBuilder
+    private var updateStatus: some View {
+        switch updateChecker.status {
+        case .idle:
+            EmptyView()
+        case .checking:
+            Text("Checking for the latest release...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .updateAvailable(let update):
+            VStack(spacing: 6) {
+                Text("Version \(update.version) is available.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Link(destination: update.releaseURL) {
+                    Label("Open Release", systemImage: "arrow.up.forward.square")
+                }
+                .font(.caption)
+            }
+        case .upToDate:
+            Text("You're up to date.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .failed(let message):
+            Text("Update check failed: \(message)")
+                .font(.caption)
+                .foregroundStyle(.red)
+                .multilineTextAlignment(.center)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a check-only update mechanism from the About window. The app now queries the latest GitHub Release, compares it with the current bundle version, and shows whether an update is available.

When a newer version is found, the UI links users to the GitHub release page instead of attempting to download, install, or replace the app.

## Validation

- `xcodebuild -scheme MacThrottle -configuration Debug -derivedDataPath .build build`
- `git diff --check HEAD~1..HEAD`
- GitHub Releases endpoint smoke check returned `v1.7.4` for a local `1.7.3` build