### PR TITLE
Fix release app signing

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -15,9 +15,6 @@ xcodebuild -project MacThrottle.xcodeproj \
     -scheme MacThrottle \
     -configuration Release \
     -derivedDataPath build \
-    CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \
     clean build
 
 # Create release directory


### PR DESCRIPTION
## Summary

- Remove the release script overrides that disabled Xcode code signing entirely.
- Let Xcode perform its default `Sign to Run Locally` ad-hoc signing during Release builds.

## Why

The published release bundle was being left with only the mandatory arm64 linker signature. That produces no sealed resources, so modern macOS versions can treat the app as structurally invalid and show a damaged-app error even after quarantine is removed.

With Xcode's normal ad-hoc signing enabled, the bundle gets sealed resources and validates correctly. The app is still not notarized, so users may still need the existing quarantine workaround for direct downloads.

## Validation

- `bash -n scripts/build-release.sh`
- `xcodebuild -project MacThrottle.xcodeproj -scheme MacThrottle -configuration Release -derivedDataPath /tmp/MacThrottlePRDefaultSigning clean build`
- `codesign --verify --deep --strict --verbose=4 /tmp/MacThrottlePRDefaultSigning/Build/Products/Release/MacThrottle.app`
- Confirmed `codesign -dvvv` reports `Signature=adhoc` and `Sealed Resources version=2`.

Note: the Release build still emits the existing Swift 6 `ThermalMonitor` Sendable warning.