### PR TITLE
fix: release HID services array

### DIFF
--- a/MacThrottle/Services/TemperatureReaders.swift
+++ b/MacThrottle/Services/TemperatureReaders.swift
@@ -327,7 +327,7 @@ final class HIDTemperatureReader {
 
     private typealias CreateFunc = @convention(c) (CFAllocator?) -> IOHIDEventSystemClientRef?
     private typealias SetMatchingFunc = @convention(c) (IOHIDEventSystemClientRef, CFDictionary?) -> Void
-    private typealias CopyServicesFunc = @convention(c) (IOHIDEventSystemClientRef) -> CFArray?
+    private typealias CopyServicesFunc = @convention(c) (IOHIDEventSystemClientRef) -> Unmanaged<CFArray>?
     private typealias CopyEventFunc = @convention(c) (IOHIDServiceClientRef, Int64, Int32, Int64) -> IOHIDEventRef?
     private typealias GetFloatValueFunc = @convention(c) (IOHIDEventRef, UInt32) -> Double
     private typealias ReleaseFunc = @convention(c) (OpaquePointer) -> Void
@@ -375,8 +375,8 @@ final class HIDTemperatureReader {
         let matching: [String: Any] = ["PrimaryUsagePage": 0xff00, "PrimaryUsage": 5]
         setMatching(client, matching as CFDictionary)
 
-        guard let services = copyServices(client) else { return nil }
-        // services (CFArray) is managed by Swift ARC
+        guard let copiedServices = copyServices(client) else { return nil }
+        let services = copiedServices.takeRetainedValue()
 
         var maxTemp: Double = 0
         let count = CFArrayGetCount(services)


### PR DESCRIPTION
## Summary

- model `IOHIDEventSystemClientCopyServices` as returning `Unmanaged<CFArray>`
- transfer the Copy-owned result with `takeRetainedValue()` so ARC releases it after each HID temperature read

## Why

The function is loaded through `dlsym`, so its function-pointer type does not retain the API's `CF_RETURNS_RETAINED` ownership annotation. Declaring the result as `CFArray?` made Swift treat it as autoreleased and left the Copy-owned reference leaked on every HID fallback poll.

## Ownership flow

```text
Before: leaked ownership
------------------------
CopyServices returns a +1 CFArray
                |
                v
         Typed as CFArray?
                |
                v
ARC balances only its assumed reference
                |
                v
 Original +1 remains retained
                |
                v
          Leak every poll


After: balanced ownership
-------------------------
CopyServices returns a +1 CFArray
                |
                v
  Typed as Unmanaged<CFArray>
                |
                v
      takeRetainedValue()
                |
                v
       ARC owns the +1
                |
                v
 ARC releases after the read
```

## Impact

Prevents sustained memory growth when SMC temperature reading is unavailable and MacThrottle polls the HID fallback every two seconds.

Might fix https://github.com/angristan/MacThrottle/issues/25