### PR TITLE
fix: ignore constant HID temperature sensors (PMU* tcal)

### DIFF
--- a/MacThrottle/Services/TemperatureReaders.swift
+++ b/MacThrottle/Services/TemperatureReaders.swift
@@ -230,7 +230,7 @@ final class SMCReader {
             }
         }
 
-        let reading = maxTemp > 0 ? TemperatureReading(value: maxTemp, source: maxKey) : nil
+        let reading = maxTemp > 0 ? TemperatureReading(value: maxTemp, source: "\(maxKey) (SMC)") : nil
         return (reading, validKeys)
     }
 
@@ -391,6 +391,7 @@ final class HIDTemperatureReader {
         let services = copiedServices.takeRetainedValue()
 
         var maxTemp: Double = 0
+        var maxProduct: String = ""
         let count = CFArrayGetCount(services)
 
         for i in 0..<count {
@@ -405,10 +406,11 @@ final class HIDTemperatureReader {
                 release(event)
                 if temp > maxTemp && temp < 150 {
                     maxTemp = temp
+                    maxProduct = product
                 }
             }
         }
 
-        return maxTemp > 0 ? TemperatureReading(value: maxTemp, source: "HID") : nil
+        return maxTemp > 0 ? TemperatureReading(value: maxTemp, source: "\(maxProduct) (HID)") : nil
     }
 }

--- a/MacThrottle/Services/TemperatureReaders.swift
+++ b/MacThrottle/Services/TemperatureReaders.swift
@@ -328,6 +328,7 @@ final class HIDTemperatureReader {
     private typealias CreateFunc = @convention(c) (CFAllocator?) -> IOHIDEventSystemClientRef?
     private typealias SetMatchingFunc = @convention(c) (IOHIDEventSystemClientRef, CFDictionary?) -> Void
     private typealias CopyServicesFunc = @convention(c) (IOHIDEventSystemClientRef) -> Unmanaged<CFArray>?
+    private typealias CopyPropertyFunc = @convention(c) (IOHIDServiceClientRef, CFString) -> Unmanaged<CFTypeRef>?
     private typealias CopyEventFunc = @convention(c) (IOHIDServiceClientRef, Int64, Int32, Int64) -> IOHIDEventRef?
     private typealias GetFloatValueFunc = @convention(c) (IOHIDEventRef, UInt32) -> Double
     private typealias ReleaseFunc = @convention(c) (OpaquePointer) -> Void
@@ -335,6 +336,7 @@ final class HIDTemperatureReader {
     private var create: CreateFunc?
     private var setMatching: SetMatchingFunc?
     private var copyServices: CopyServicesFunc?
+    private var copyProperty: CopyPropertyFunc?
     private var copyEvent: CopyEventFunc?
     private var getFloatValue: GetFloatValueFunc?
     private var release: ReleaseFunc?
@@ -363,6 +365,7 @@ final class HIDTemperatureReader {
         create = unsafeBitCast(dlsym(handle, "IOHIDEventSystemClientCreate"), to: CreateFunc?.self)
         setMatching = unsafeBitCast(dlsym(handle, "IOHIDEventSystemClientSetMatching"), to: SetMatchingFunc?.self)
         copyServices = unsafeBitCast(dlsym(handle, "IOHIDEventSystemClientCopyServices"), to: CopyServicesFunc?.self)
+        copyProperty = unsafeBitCast(dlsym(handle, "IOHIDServiceClientCopyProperty"), to: CopyPropertyFunc?.self)
         copyEvent = unsafeBitCast(dlsym(handle, "IOHIDServiceClientCopyEvent"), to: CopyEventFunc?.self)
         getFloatValue = unsafeBitCast(dlsym(handle, "IOHIDEventGetFloatValue"), to: GetFloatValueFunc?.self)
         release = unsafeBitCast(dlsym(handle, "CFRelease"), to: ReleaseFunc?.self)
@@ -381,7 +384,8 @@ final class HIDTemperatureReader {
     func readCPUTemperature() -> TemperatureReading? {
         ensureInitialized()
 
-        guard let copyServices, let copyEvent, let getFloatValue, let release, let client else { return nil }
+        guard let copyServices, let copyProperty, let copyEvent,
+              let getFloatValue, let release, let client else { return nil }
 
         guard let copiedServices = copyServices(client) else { return nil }
         let services = copiedServices.takeRetainedValue()
@@ -391,6 +395,10 @@ final class HIDTemperatureReader {
 
         for i in 0..<count {
             let service = unsafeBitCast(CFArrayGetValueAtIndex(services, i), to: IOHIDServiceClientRef.self)
+            let product = copyProperty(service, kIOHIDProductKey as CFString)?
+                .takeRetainedValue() as? String ?? "Unknown"
+
+            guard !(product.hasPrefix("PMU") && product.hasSuffix(" tcal")) else { continue }
 
             if let event = copyEvent(service, kIOHIDEventTypeTemperature, 0, 0) {
                 let temp = getFloatValue(event, kIOHIDEventFieldTemperatureLevel)


### PR DESCRIPTION
The HID temperature was lower-bounded by that of constant sensors (PMU* tcal).