### PR TITLE
fix: monospaced digit menu bar icon

### DIFF
--- a/MacThrottle/Views/MenuBarIcon.swift
+++ b/MacThrottle/Views/MenuBarIcon.swift
@@ -6,14 +6,14 @@ struct MenuBarIcon: View {
     let showTemperature: Bool
 
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: iconName)
-                .symbolRenderingMode(.palette)
-                .foregroundStyle(pressure.color, .primary)
-            if showTemperature, let temp = temperature {
-                Text("\(Int(temp.rounded()))°")
-                    .monospacedDigit()
+        Image(systemName: iconName)
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(pressure.color, .primary)
+            .onAppear {
+                getStatusItems()?.first?.button?.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
             }
+        if showTemperature, let temp = temperature {
+            Text("\(Int(temp.rounded()))°")
         }
     }
 
@@ -25,5 +25,17 @@ struct MenuBarIcon: View {
         case .critical: return "thermometer.sun.fill"
         case .unknown: return "thermometer.variable.and.figure"
         }
+    }
+
+    private func getStatusItems() -> [NSStatusItem]? {
+        let statusBar = NSStatusBar.system
+
+        guard
+            statusBar.responds(to: NSSelectorFromString("_statusItems")),
+            let statusItemsPointer = statusBar.value(forKey: "_statusItems") as? NSPointerArray,
+            let statusItems = statusItemsPointer.allObjects as? [NSStatusItem]
+        else { return nil }
+
+        return statusItems
     }
 }


### PR DESCRIPTION
A hacky way to change the style of the menu bar icon with AppKit, as SwiftUI seems to ignore it.