### PR TITLE
fix: graph tooltip ignores cursor

### DIFF
--- a/MacThrottle/Views/HistoryViews.swift
+++ b/MacThrottle/Views/HistoryViews.swift
@@ -96,6 +96,7 @@ struct HistoryGraphView: View {
                 .onPreferenceChange(WidthPreferenceKey.self) { graphWidth = $0 }
                 .overlay(alignment: .topTrailing) {
                     tooltipView
+                        .allowsHitTesting(false)
                 }
 
             HStack {


### PR DESCRIPTION
This prevents the graph entry from being deselected when the cursor hovers over the tooltip.